### PR TITLE
Add EIP712 signing

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,9 +1,9 @@
 // AA smart contract deployment
 export const SMART_ACCOUNT_FACTORY_ADDRESS =
-  "0x8ab6915749F7a6f9831834757Ef1C14674E36D15";
+  "0xb872F3992D6c594bA94aAf2d14E6a5cF9ab0C86C";
 
 // AA wallet validator contract deployment
-export const VALIDATOR_ADDRESS = "0xba32cA59dEc70Bf33bD600740d0cb5F614a08cf3";
+export const VALIDATOR_ADDRESS = "0x84d17983DCf2431916e9Bf0574A998a1A35d58f5";
 
 // Sample NFT deployed to Abstract Testnet
 export const NFT_ADDRESS = "0xC4822AbB9F05646A9Ce44EFa6dDcda0Bf45595AA";
@@ -12,6 +12,6 @@ export const NFT_ADDRESS = "0xC4822AbB9F05646A9Ce44EFa6dDcda0Bf45595AA";
 export const NFT_PAYMASTER_ADDRESS = "0xa8dA6C5bf7dA8c2D5A642D3dcc0E04D68D134806";
 
 // Sample paymaster that sponsors AA wallet creation
-export const AA_FACTORY_PAYMASTER_ADDRESS = "0xD256F2783DF5cc669AEB60d0c5666DD3dB5f6110";
+export const AA_FACTORY_PAYMASTER_ADDRESS = "0x5407B5040dec3D339A9247f3654E59EEccbb6391";
 
 export const ABS_SEPOLIA_SCAN_URL = "https://explorer.testnet.abs.xyz";


### PR DESCRIPTION
We don't want users to sign raw hashes, instead we'll have them sign nicely formatted EIP712 messages.

I apologize @jarrodwatts, but we'll have to redo some of your PR to account for these changes.